### PR TITLE
Create panels in node dashboard for network metrics

### DIFF
--- a/grafana/provisioning/dashboards/qumulo_node.json
+++ b/grafana/provisioning/dashboards/qumulo_node.json
@@ -696,7 +696,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "rate(qumulo_network_interface_received_bytes_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[5m])",
+          "expr": "rate(qumulo_network_interface_received_bytes_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval])",
           "hide": false,
           "legendFormat": "Received node{{node_id}} {{role}} {{interface}}",
           "range": true,


### PR DESCRIPTION
This adds panels for networking health and general functionality. It also includes a few minor visual updates to other metrics.

![Screen Shot 2022-10-13 at 10 08 57 AM](https://user-images.githubusercontent.com/60160500/195661485-35ed51fe-4d43-4ed8-9262-91e5af10f236.png)
