### PR TITLE
Replace all instances of $$variable in grafana templates with $variable

### DIFF
--- a/grafana/provisioning/alerting/correctable_ecc_error_alert_rule.yaml
+++ b/grafana/provisioning/alerting/correctable_ecc_error_alert_rule.yaml
@@ -65,7 +65,7 @@ groups:
         for: 0s
         annotations:
           description: >-
-            There are correctable ECC errors on node {{ $$labels.node_id }}. Repeated or large
+            There are correctable ECC errors on node {{ $labels.node_id }}. Repeated or large
             numbers of correctable ECC error are an indicator that the memory will fail.
         labels:
           severity: warning

--- a/grafana/provisioning/alerting/cpu_temperature_alert_rule.yaml
+++ b/grafana/provisioning/alerting/cpu_temperature_alert_rule.yaml
@@ -66,8 +66,8 @@ groups:
         for: 5m
         annotations:
           description: >-
-            CPU {{ $$labels.cpu }} on node {{ $$labels.node_id }} has a temperature of
-            {{ $$values.average_cpu_temperature.Value }} C which is over the threshold of 85 C.
+            CPU {{ $labels.cpu }} on node {{ $labels.node_id }} has a temperature of
+            {{ $values.average_cpu_temperature.Value }} C which is over the threshold of 85 C.
             Please verify that your cooling systems are functional.
         labels:
           severity: critical

--- a/grafana/provisioning/alerting/disk_is_unhealthy_alert_rule.yaml
+++ b/grafana/provisioning/alerting/disk_is_unhealthy_alert_rule.yaml
@@ -50,8 +50,8 @@ groups:
         for: 5m
         annotations:
           description: >-
-            The {{ $$labels.disk_type }} at drive bay {{ $$labels.drive_bay }} on node
-            {{ $$labels.node_id }} has errors, has been removed from the cluster, or is otherwise
+            The {{ $labels.disk_type }} at drive bay {{ $labels.drive_bay }} on node
+            {{ $labels.node_id }} has errors, has been removed from the cluster, or is otherwise
             unusable. Please replace the disk as soon as possible.
         labels:
           severity: critical

--- a/grafana/provisioning/alerting/fan_is_stopped_alert_rule.yaml
+++ b/grafana/provisioning/alerting/fan_is_stopped_alert_rule.yaml
@@ -65,7 +65,7 @@ groups:
         for: 5m
         annotations:
           description: >-
-            The {{ $$labels.fan }} fan on node {{ $$labels.node_id }} has stopped. Please replace
+            The {{ $labels.fan }} fan on node {{ $labels.node_id }} has stopped. Please replace
             the fan as soon as possible.
         labels:
           severity: critical

--- a/grafana/provisioning/alerting/low_free_space_alert_rule.yaml
+++ b/grafana/provisioning/alerting/low_free_space_alert_rule.yaml
@@ -147,9 +147,9 @@ groups:
           __dashboardUid__: isJoSTGVz
           __panelId__: '22'
           description: >-
-            The cluster {{ $$values.info.Labels.name }} has
-            {{ humanizePercentage $$values.percent_free.Value }}
-            ({{ humanize $$values.mean_free.Value }}) remaining capacity, which is below the
+            The cluster {{ $values.info.Labels.name }} has
+            {{ humanizePercentage $values.percent_free.Value }}
+            ({{ humanize $values.mean_free.Value }}) remaining capacity, which is below the
             threshold of 10%. Consider expanding capacity soon.
         labels:
           severity: warning

--- a/grafana/provisioning/alerting/network_interface_is_down_alert_rule.yaml
+++ b/grafana/provisioning/alerting/network_interface_is_down_alert_rule.yaml
@@ -48,7 +48,7 @@ groups:
         for: 5m
         annotations:
           description: >-
-            The {{ $$labels.interface }} network interface on node {{ $$labels.node_id }} is down.
+            The {{ $labels.interface }} network interface on node {{ $labels.node_id }} is down.
             Please verify that the network interface is cabled properly.
         labels:
           severity: critical

--- a/grafana/provisioning/alerting/node_is_offline_alert_rule.yaml
+++ b/grafana/provisioning/alerting/node_is_offline_alert_rule.yaml
@@ -49,7 +49,7 @@ groups:
         for: 5m
         annotations:
           description: >-
-            Node {{ $$labels.node_id }} is offline. Please verify that the node is powered on and
+            Node {{ $labels.node_id }} is offline. Please verify that the node is powered on and
             its network interfaces are cabled correctly.
         labels:
           severity: critical

--- a/grafana/provisioning/alerting/power_supply_is_unhealthy_alert_rule.yaml
+++ b/grafana/provisioning/alerting/power_supply_is_unhealthy_alert_rule.yaml
@@ -48,7 +48,7 @@ groups:
         for: 5m
         annotations:
           description: >-
-            The {{ $$labels.location }} power supply on node {{ $$labels.node_id }} is unplugged,
+            The {{ $labels.location }} power supply on node {{ $labels.node_id }} is unplugged,
             removed, dead, or otherwise unhealthy. Please connect or replace the power supply as
             soon as possible.
         labels:

--- a/grafana/provisioning/alerting/time_is_not_synchronized_alert_rule.yaml
+++ b/grafana/provisioning/alerting/time_is_not_synchronized_alert_rule.yaml
@@ -48,7 +48,7 @@ groups:
         for: 1h
         annotations:
           description: >-
-            The time on node {{ $$labels.node_id }} is no longer being synchronized with a time
+            The time on node {{ $labels.node_id }} is no longer being synchronized with a time
             server. Eventually the time may drift. Please verify the node's ability to reach the
             time server.
         labels:


### PR DESCRIPTION
Despite what the documentation suggests, $variable is the correct way to expand a variable in grafana alert templates. Otherwise, the templater throws an error  and does not expand the variables.

With double $$:

> - description = There are correctable ECC errors on node {{ $$labels.node_id }}. Repeated or large numbers of correctable ECC error are an indicator that the memory will fail.


With single $:
>- description = There are correctable ECC errors on node 4. Repeated or large numbers of correctable ECC error are an indicator that the memory will fail.