### PR TITLE
Update free_space_alert to do math on in the prometheus query.

### DIFF
--- a/grafana/provisioning/alerting/low_free_space_alert_rule.yaml
+++ b/grafana/provisioning/alerting/low_free_space_alert_rule.yaml
@@ -11,6 +11,43 @@ groups:
         title: Low free space
         condition: Less than 10% free space
         data:
+          - refId: percent_free
+            queryType: ''
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: builder
+              expr: qumulo_fs_free_bytes / qumulo_fs_capacity_bytes
+              hide: false
+              interval: ''
+              intervalMs: 15000
+              legendFormat: free
+              maxDataPoints: 43200
+              range: true
+              refId: percent_free
+          - refId: mean_percent_free
+            queryType: ''
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: '-100'
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: percent_free
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: mean
+              refId: mean_percent_free
+              type: reduce
           - refId: free
             queryType: ''
             relativeTimeRange:
@@ -48,60 +85,6 @@ groups:
               reducer: mean
               refId: mean_free
               type: reduce
-          - refId: capacity
-            queryType: ''
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: PBFA97CFB590B2093
-            model:
-              datasource:
-                type: prometheus
-                uid: PBFA97CFB590B2093
-              editorMode: builder
-              expr: qumulo_fs_capacity_bytes
-              hide: false
-              interval: ''
-              intervalMs: 15000
-              legendFormat: capacity
-              maxDataPoints: 43200
-              range: true
-              refId: capacity
-          - refId: mean_capacity
-            queryType: ''
-            relativeTimeRange:
-              from: 0
-              to: 0
-            datasourceUid: '-100'
-            model:
-              datasource:
-                name: Expression
-                type: __expr__
-                uid: __expr__
-              expression: capacity
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              reducer: mean
-              refId: mean_capacity
-              type: reduce
-          - refId: percent_free
-            queryType: ''
-            relativeTimeRange:
-              from: 0
-              to: 0
-            datasourceUid: '-100'
-            model:
-              datasource:
-                name: Expression
-                type: __expr__
-                uid: __expr__
-              expression: $mean_free / $mean_capacity
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              refId: percent_free
-              type: math
           - refId: Less than 10% free space
             queryType: ''
             relativeTimeRange:
@@ -113,7 +96,7 @@ groups:
                 name: Expression
                 type: __expr__
                 uid: __expr__
-              expression: ${percent_free} < 0.1
+              expression: ${mean_percent_free} < 0.1
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
@@ -139,7 +122,6 @@ groups:
               maxDataPoints: 43200
               range: false
               refId: info
-        updated: '2022-10-26T18:50:59Z'
         noDataState: NoData
         execErrState: Error
         for: 1h
@@ -148,7 +130,7 @@ groups:
           __panelId__: '22'
           description: >-
             The cluster {{ $values.info.Labels.name }} has
-            {{ humanizePercentage $values.percent_free.Value }}
+            {{ humanizePercentage $values.mean_percent_free.Value }}
             ({{ humanize $values.mean_free.Value }}) remaining capacity, which is below the
             threshold of 10%. Consider expanding capacity soon.
         labels:


### PR DESCRIPTION
Doing math on the grafana side would be idea, but doesn't quite work due to grafana labeling each query's result with the field name, meaning that the labels don't match up when doing math across multiple fields. Doing it on prometheus's side means we don't have to deal with that.