### PR TITLE
Misc cleanup and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,43 +80,39 @@ For this section, follow [Working with Qumulo Access Tokens](https://docs.qumulo
 
    * In the `tls_config` block, for `insecure_skip_verify`: If the Qumulo cluster uses the default, self-signed SSL certificate, set this value to `true`.
 
-1. (Optional) Before you start Prometheus and Grafana, change the default administrator credentials.
+1. (Optional) Before you start Prometheus and Grafana, change the default administrator credentials in [`docker-compose.yml`](/docker-compose.yml#L62).
 
-   a. Open the [`docker-compose.yml`](/docker-compose.yml#L62) file for editing.
+   * For `ADMIN_USER` and `ADMIN_PASSWORD`, specify credentials that conform to your security policies.
+   
+     **⚠️ Important:** If you don't specify your credentials, Docker uses the default values.
+   
+   * For `ADMIN_PASSWORD_HASH`, specify the password hash. To [generate the hash for your password](https://caddyserver.com/docs/command-line#caddy-hash-password), install and run [the version of `caddy`](https://caddyserver.com/docs/install) that matches the version of the container that the Qumulo Monitoring Dashboard uses (2.6.2).
+   
+   **ℹ️ Note:**  Alternatively, you can set your credentials as environment variables:
 
-   b. For `ADMIN_USER` and `ADMIN_PASSWORD`, specify credentials that conform to your security policies.
-   
-     **⚠️ Important:** If you don't specify values, Docker uses the default values.
-   
-   c. For `ADMIN_PASSWORD_HASH`, specify the password hash. To [generate the hash for your password](https://caddyserver.com/docs/command-line#caddy-hash-password), use the `caddy` CLI tool.
-   
-     **ℹ️ Note:** Install [the version of `caddy`](https://caddyserver.com/docs/install) that matches the version of the container that the Qumulo Monitoring Dashboard uses (2.6.2).
-   
-   d. You can set your three credentials as environment variables:
-
-      * On Linux:
+   * On Linux:
       
-        i. To set the environment variables, use the `export` command.
+     a. To set the environment variables, use the `export` command.
       
-           ```bash
-           export ADMIN_USER='<username>'
-           export ADMIN_PASSWORD='<password>'
-           export ADMIN_PASSWORD_HASH='<password-hash>'
-           ```
+        ```bash
+        export ADMIN_USER='<username>'
+        export ADMIN_PASSWORD='<password>'
+        export ADMIN_PASSWORD_HASH='<password-hash>'
+        ```
            
-        ii. To verify the environment variables, use the `printenv` command.
+     b. To verify the environment variables, use the `printenv` command.
       
-      * On Windows:
+   * On Windows:
       
-        i. To set the environment variables, use the `setx` command.
+     a. To set the environment variables, use the `setx` command.
       
-           ```powershell
-           setx ADMIN_USER "<username>"
-           setx ADMIN_PASSWORD <password>
-           setx ADMIN_PASSWORD_HASH <password-hash>
-           ```
+        ```powershell
+        setx ADMIN_USER "<username>"
+        setx ADMIN_PASSWORD <password>
+        setx ADMIN_PASSWORD_HASH <password-hash>
+        ```
            
-        ii. To verify the environment variables, use the `set` command.
+     b. To verify the environment variables, use the `set` command.
         
 <a id="start-prometheus-grafana"></a>
 ### Step 4: Start Prometheus and Grafana

--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -38,40 +38,58 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "uuid"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 286
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 2,
-        "w": 3,
+        "h": 3,
+        "w": 12,
         "x": 0,
         "y": 0
       },
-      "id": 31,
+      "id": 63,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^name$/",
-          "values": false
+          "show": false
         },
-        "text": {},
-        "textMode": "auto"
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "9.2.2",
       "targets": [
@@ -81,387 +99,54 @@
             "uid": "${datasource}"
           },
           "editorMode": "builder",
+          "exemplar": false,
           "expr": "qumulo_info{instance=~\"$cluster\"}",
           "format": "table",
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Cluster Name",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
+      "title": "Cluster Info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 11,
+              "__name__": 1,
+              "instance": 2,
+              "job": 3,
+              "max_drive_failures": 9,
+              "max_node_failures": 10,
+              "name": 4,
+              "platform": 7,
+              "service_model": 8,
+              "uuid": 5,
+              "version": 6
+            },
+            "renameByName": {
+              "max_drive_failures": "Max Drive Failures",
+              "max_node_failures": "Max Node Failures",
+              "name": "Cluster Name",
+              "platform": "Platform",
+              "service_model": "Service Model",
+              "uuid": "Cluster UUID",
+              "version": "Software Version"
+            }
           }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 3,
-        "y": 0
-      },
-      "id": 35,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^version$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
         }
       ],
-      "title": "Version",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 5,
-        "y": 0
-      },
-      "id": 33,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^uuid$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "UUID",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 0,
-        "y": 2
-      },
-      "id": 58,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^service_model$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Service Model",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 2,
-        "y": 2
-      },
-      "id": 59,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^platform$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Platform",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 4,
-        "y": 2
-      },
-      "id": 60,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^max_node_failures$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Node Failures",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 7,
-        "y": 2
-      },
-      "id": 61,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^max_drive_failures$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Drive Failures",
-      "type": "stat"
+      "type": "table"
     },
     {
       "collapsed": false,
@@ -469,7 +154,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 4
+        "y": 3
       },
       "id": 45,
       "panels": [],
@@ -549,7 +234,7 @@
         "h": 8,
         "w": 5,
         "x": 0,
-        "y": 5
+        "y": 4
       },
       "id": 14,
       "links": [],
@@ -671,7 +356,7 @@
         "h": 8,
         "w": 6,
         "x": 5,
-        "y": 5
+        "y": 4
       },
       "id": 22,
       "options": {
@@ -752,7 +437,7 @@
         "h": 8,
         "w": 4,
         "x": 11,
-        "y": 5
+        "y": 4
       },
       "id": 8,
       "options": {
@@ -850,7 +535,7 @@
         "h": 8,
         "w": 6,
         "x": 15,
-        "y": 5
+        "y": 4
       },
       "id": 51,
       "options": {
@@ -887,7 +572,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 12
       },
       "id": 43,
       "panels": [],
@@ -952,7 +637,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 14
+        "y": 13
       },
       "id": 10,
       "options": {
@@ -1041,7 +726,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 14
+        "y": 13
       },
       "id": 12,
       "options": {
@@ -1142,7 +827,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 14
+        "y": 13
       },
       "id": 49,
       "options": {
@@ -1230,7 +915,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 22
+        "y": 21
       },
       "id": 16,
       "options": {
@@ -1319,7 +1004,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 22
+        "y": 21
       },
       "id": 6,
       "options": {
@@ -1409,7 +1094,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 22
+        "y": 21
       },
       "id": 4,
       "options": {
@@ -1447,7 +1132,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 41,
       "panels": [],
@@ -1511,7 +1196,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 31
+        "y": 30
       },
       "id": 39,
       "options": {
@@ -1600,7 +1285,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 31
+        "y": 30
       },
       "id": 47,
       "options": {
@@ -1688,7 +1373,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 31
+        "y": 30
       },
       "id": 37,
       "options": {
@@ -1776,7 +1461,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 39
+        "y": 38
       },
       "id": 53,
       "options": {
@@ -1864,7 +1549,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 39
+        "y": 38
       },
       "id": 55,
       "options": {
@@ -1952,7 +1637,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 39
+        "y": 38
       },
       "id": 57,
       "options": {
@@ -2065,7 +1750,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 47
+        "y": 46
       },
       "id": 26,
       "options": {
@@ -2154,7 +1839,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 47
+        "y": 46
       },
       "id": 27,
       "options": {
@@ -2242,7 +1927,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 47
+        "y": 46
       },
       "id": 29,
       "options": {
@@ -2366,6 +2051,6 @@
   "timezone": "",
   "title": "Cluster Overview",
   "uid": "isJoSTGVz",
-  "version": 3,
+  "version": 6,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
+  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -73,7 +73,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.2",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
           "datasource": {
@@ -135,7 +135,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.2",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
           "datasource": {
@@ -197,7 +197,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.2",
+      "pluginVersion": "9.2.2",
       "targets": [
         {
           "datasource": {
@@ -216,12 +216,260 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 0,
+        "y": 2
+      },
+      "id": 58,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^service_model$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Service Model",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 2
+      },
+      "id": 59,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^platform$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 4,
+        "y": 2
+      },
+      "id": 60,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^max_node_failures$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Node Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 7,
+        "y": 2
+      },
+      "id": 61,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^max_disk_failures$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Disk Failures",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 2
+        "y": 4
       },
       "id": 45,
       "panels": [],
@@ -301,7 +549,7 @@
         "h": 8,
         "w": 5,
         "x": 0,
-        "y": 3
+        "y": 5
       },
       "id": 14,
       "links": [],
@@ -423,7 +671,7 @@
         "h": 8,
         "w": 6,
         "x": 5,
-        "y": 3
+        "y": 5
       },
       "id": 22,
       "options": {
@@ -504,7 +752,7 @@
         "h": 8,
         "w": 4,
         "x": 11,
-        "y": 3
+        "y": 5
       },
       "id": 8,
       "options": {
@@ -602,7 +850,7 @@
         "h": 8,
         "w": 6,
         "x": 15,
-        "y": 3
+        "y": 5
       },
       "id": 51,
       "options": {
@@ -639,7 +887,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 11
+        "y": 13
       },
       "id": 43,
       "panels": [],
@@ -704,7 +952,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 12
+        "y": 14
       },
       "id": 10,
       "options": {
@@ -793,7 +1041,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 12
+        "y": 14
       },
       "id": 12,
       "options": {
@@ -894,7 +1142,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 12
+        "y": 14
       },
       "id": 49,
       "options": {
@@ -982,7 +1230,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 20
+        "y": 22
       },
       "id": 16,
       "options": {
@@ -1071,7 +1319,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 20
+        "y": 22
       },
       "id": 6,
       "options": {
@@ -1161,7 +1409,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 20
+        "y": 22
       },
       "id": 4,
       "options": {
@@ -1199,7 +1447,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 41,
       "panels": [],
@@ -1251,8 +1499,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1264,7 +1511,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 29
+        "y": 31
       },
       "id": 39,
       "options": {
@@ -1341,8 +1588,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1354,7 +1600,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 29
+        "y": 31
       },
       "id": 47,
       "options": {
@@ -1430,8 +1676,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1443,7 +1688,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 29
+        "y": 31
       },
       "id": 37,
       "options": {
@@ -1519,8 +1764,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1532,7 +1776,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 37
+        "y": 39
       },
       "id": 53,
       "options": {
@@ -1608,8 +1852,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1621,7 +1864,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 37
+        "y": 39
       },
       "id": 55,
       "options": {
@@ -1697,8 +1940,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1710,7 +1952,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 37
+        "y": 39
       },
       "id": 57,
       "options": {
@@ -1786,8 +2028,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1824,7 +2065,7 @@
         "h": 8,
         "w": 7,
         "x": 0,
-        "y": 45
+        "y": 47
       },
       "id": 26,
       "options": {
@@ -1901,8 +2142,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -1914,7 +2154,7 @@
         "h": 8,
         "w": 7,
         "x": 7,
-        "y": 45
+        "y": 47
       },
       "id": 27,
       "options": {
@@ -1990,8 +2230,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -2003,7 +2242,7 @@
         "h": 8,
         "w": 7,
         "x": 14,
-        "y": 45
+        "y": 47
       },
       "id": 29,
       "options": {
@@ -2109,6 +2348,6 @@
   "timezone": "",
   "title": "Cluster Overview",
   "uid": "isJoSTGVz",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -78,7 +78,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -94,7 +94,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -140,7 +140,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -156,7 +156,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -202,7 +202,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -218,7 +218,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -264,7 +264,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -280,7 +280,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -326,7 +326,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -342,7 +342,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -388,7 +388,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -404,7 +404,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -450,7 +450,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -479,7 +479,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -581,7 +581,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -595,7 +595,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -612,7 +612,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -690,7 +690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fs_directory_used_bytes{instance=~\"$cluster\"}",
@@ -701,7 +701,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fs_free_bytes{instance=~\"$cluster\"}",
@@ -713,7 +713,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fs_capacity_bytes{instance=~\"$cluster\"}",
@@ -729,7 +729,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -781,7 +781,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fs_directory_tree_entries{instance=~\"$cluster\"}",
@@ -796,7 +796,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -869,7 +869,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fs_snapshots{instance=~\"$cluster\"}",
@@ -897,7 +897,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -971,7 +971,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "sum by(io_type) (rate(qumulo_protocol_operation_bytes_total{instance=~\"$cluster\"}[$__rate_interval]))",
@@ -986,7 +986,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1060,7 +1060,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "sum(rate(qumulo_protocol_operations_total{instance=~\"$cluster\", io_type=\"read\"}[$__rate_interval]))",
@@ -1071,7 +1071,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "sum(rate(qumulo_protocol_operations_total{instance=~\"$cluster\", io_type=\"write\"}[$__rate_interval]))",
@@ -1087,7 +1087,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1161,7 +1161,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "sum by(protocol, io_type, data_type) (rate(qumulo_protocol_operation_latency_seconds_sum{instance=~\"$cluster\"}[$__rate_interval])) / sum by(protocol, io_type, data_type) (rate(qumulo_protocol_operation_latency_seconds_count{instance=~\"$cluster\"}[$__rate_interval]))",
@@ -1176,7 +1176,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1249,7 +1249,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_protocol_client_connections_total{instance=~\"$cluster\"} - qumulo_protocol_client_disconnections_total{instance=~\"$cluster\"}",
@@ -1264,7 +1264,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1338,7 +1338,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_protocol_operations_total{op_name=~\"$busy_ops\", instance=~\"$cluster\"}[$__rate_interval])",
@@ -1353,7 +1353,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1428,7 +1428,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_protocol_operation_latency_seconds_sum{op_name=~\"$busy_ops\", instance=\"$cluster\"}[$__rate_interval]) / rate(qumulo_protocol_operation_latency_seconds_count{op_name=~\"$busy_ops\", instance=\"$cluster\"}[$__rate_interval])",
@@ -1457,7 +1457,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1530,7 +1530,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ad_netlogon_requests_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1545,7 +1545,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1619,7 +1619,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ad_netlogon_request_errors_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1634,7 +1634,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1707,7 +1707,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(qumulo_ad_netlogon_request_latency_seconds_sum{instance=~\"$cluster\"}[$__rate_interval]) / rate(qumulo_ad_netlogon_request_latency_seconds_count{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1722,7 +1722,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1795,7 +1795,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operations_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1810,7 +1810,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1883,7 +1883,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operation_errors_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1898,7 +1898,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -1971,7 +1971,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operation_referrals_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1986,7 +1986,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2084,7 +2084,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(qumulo_ldap_lookup_requests_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -2100,7 +2100,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2173,7 +2173,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_lookup_request_errors_total{instance=~\"$cluster\"}[$__rate_interval])",
@@ -2188,7 +2188,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -2261,7 +2261,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "code",
           "expr": "rate(qumulo_ldap_lookup_request_latency_seconds_sum{instance=~\"$cluster\"}[$__rate_interval]) / rate(qumulo_ldap_lookup_request_latency_seconds_count{instance=~\"$cluster\"}[$__rate_interval])",
@@ -2282,6 +2282,24 @@
   ],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "The Prometheus instance to query OpenMetrics from",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
       {
         "current": {
           "selected": true,
@@ -2348,6 +2366,6 @@
   "timezone": "",
   "title": "Cluster Overview",
   "uid": "isJoSTGVz",
-  "version": 5,
+  "version": 3,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -440,7 +440,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^max_disk_failures$/",
+          "fields": "/^max_drive_failures$/",
           "values": false
         },
         "textMode": "auto"
@@ -460,7 +460,7 @@
           "refId": "A"
         }
       ],
-      "title": "Max Disk Failures",
+      "title": "Max Drive Failures",
       "type": "stat"
     },
     {
@@ -2348,6 +2348,6 @@
   "timezone": "",
   "title": "Cluster Overview",
   "uid": "isJoSTGVz",
-  "version": 3,
+  "version": 5,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -757,7 +757,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -768,7 +769,7 @@
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 30
+            "y": 28
           },
           "id": 57,
           "options": {
@@ -849,7 +850,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -865,7 +867,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 37
+            "y": 35
           },
           "id": 24,
           "options": {
@@ -915,7 +917,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "green",
@@ -931,7 +934,7 @@
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 45
+            "y": 43
           },
           "id": 63,
           "options": {
@@ -953,10 +956,13 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "editorMode": "builder",
-              "expr": "qumulo_disk_endurance_percent{instance=~\"$cluster\"}",
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "last_over_time(qumulo_disk_endurance_percent{instance=~\"$cluster\"}[24h])",
+              "format": "time_series",
+              "instant": true,
               "legendFormat": "node {{node_id}} bay {{drive_bay}}",
-              "range": true,
+              "range": false,
               "refId": "A"
             }
           ],
@@ -1009,7 +1015,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1020,7 +1027,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 52
+            "y": 50
           },
           "id": 68,
           "options": {
@@ -1041,8 +1048,8 @@
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "editorMode": "builder",
-              "expr": "qumulo_disk_uncorrectable_media_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
+              "editorMode": "code",
+              "expr": "last_over_time(qumulo_disk_uncorrectable_media_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[24h])",
               "legendFormat": "Node {{node_id}} bay {{drive_bay}} ({{disk_type}})",
               "range": true,
               "refId": "A"
@@ -1097,7 +1104,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1133,7 +1141,7 @@
             "h": 8,
             "w": 10,
             "x": 10,
-            "y": 52
+            "y": 50
           },
           "id": 69,
           "options": {
@@ -1155,7 +1163,7 @@
                 "uid": "${datasource}"
               },
               "editorMode": "builder",
-              "expr": "qumulo_disk_transport_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
+              "expr": "last_over_time(qumulo_disk_transport_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[24h])",
               "legendFormat": "Node {{node_id}} bay {{drive_bay}} ({{disk_type}})",
               "range": true,
               "refId": "A"
@@ -1773,13 +1781,13 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 12,
+  "version": 15,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -536,7 +536,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "fields": "/^max_disk_failures$/",
+          "fields": "/^max_drive_failures$/",
           "values": false
         },
         "textMode": "auto"
@@ -556,7 +556,7 @@
           "refId": "A"
         }
       ],
-      "title": "Max Disk Failures",
+      "title": "Max Drive Failures",
       "type": "stat"
     },
     {
@@ -2067,6 +2067,6 @@
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 4,
+  "version": 7,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -31,7 +31,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -57,7 +57,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 53,
+      "id": 77,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -78,7 +78,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -94,7 +94,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -140,7 +140,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -156,7 +156,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -202,7 +202,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -218,7 +218,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -295,7 +295,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": true,
@@ -314,7 +314,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -360,7 +360,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -376,7 +376,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -422,7 +422,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -438,7 +438,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -484,7 +484,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -500,7 +500,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -546,7 +546,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_info{instance=~\"$cluster\"}",
@@ -562,7 +562,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -589,7 +589,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 20,
         "x": 0,
         "y": 4
@@ -614,7 +614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_node_info{instance=~\"$cluster\"}",
@@ -630,7 +630,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -658,7 +658,7 @@
         "h": 4,
         "w": 20,
         "x": 0,
-        "y": 8
+        "y": 7
       },
       "id": 55,
       "options": {
@@ -680,10 +680,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
-          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\"}",
+          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\", node_id=~\"$nodes\"}",
           "format": "heatmap",
           "legendFormat": "node {{node_id}}",
           "range": true,
@@ -696,7 +696,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -752,7 +752,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 12
+        "y": 11
       },
       "id": 31,
       "options": {
@@ -771,7 +771,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_cpu_temperature_celsius{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -782,7 +782,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "min(qumulo_cpu_max_temperature_celsius{instance=~\"$cluster\", node_id=~\"$nodes\"})",
@@ -812,7 +812,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "fieldConfig": {
         "defaults": {
@@ -868,7 +868,7 @@
         "h": 8,
         "w": 10,
         "x": 10,
-        "y": 12
+        "y": 11
       },
       "id": 34,
       "options": {
@@ -887,7 +887,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_fan_speed_rpm{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -902,7 +902,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -934,7 +934,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 20
+        "y": 19
       },
       "id": 33,
       "options": {
@@ -956,7 +956,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "expr": "qumulo_memory_correctable_ecc_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -972,7 +972,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "uid": "${datasource}"
       },
       "description": "",
       "fieldConfig": {
@@ -1001,7 +1001,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 25
+        "y": 24
       },
       "id": 35,
       "options": {
@@ -1023,7 +1023,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "editorMode": "builder",
           "exemplar": false,
@@ -1044,14 +1044,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 59,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1063,7 +1063,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1074,7 +1075,7 @@
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 25
+            "y": 30
           },
           "id": 57,
           "options": {
@@ -1096,7 +1097,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "exemplar": false,
@@ -1113,7 +1114,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1155,7 +1156,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1171,7 +1173,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 32
+            "y": 37
           },
           "id": 24,
           "options": {
@@ -1190,7 +1192,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "rate(qumulo_disk_operation_latency_seconds_sum{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval]) / rate(qumulo_disk_operation_latency_seconds_count{instance=~\"$cluster\"}[$__rate_interval])",
@@ -1205,7 +1207,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -1221,7 +1223,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "green",
@@ -1237,7 +1240,7 @@
             "h": 7,
             "w": 20,
             "x": 0,
-            "y": 40
+            "y": 45
           },
           "id": 63,
           "options": {
@@ -1257,10 +1260,10 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
-              "expr": "qumulo_disk_endurance_percent{instance=~\"$cluster\", node_id=~\"$nodes\"}",
+              "expr": "qumulo_disk_endurance_percent{instance=~\"$cluster\"}",
               "legendFormat": "node {{node_id}} bay {{drive_bay}}",
               "range": true,
               "refId": "A"
@@ -1272,7 +1275,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Uncorrectable media errors are failures to read or write to the physical disk that could not be resolved using error correction technology. These errors can lead to reallocating sectors. Large or rapidly increasing numbers of media errors may be an indicator that a drive will fail, especially on HDDs.",
           "fieldConfig": {
@@ -1315,7 +1318,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1326,7 +1330,7 @@
             "h": 8,
             "w": 10,
             "x": 0,
-            "y": 47
+            "y": 52
           },
           "id": 68,
           "options": {
@@ -1345,7 +1349,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_disk_uncorrectable_media_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -1360,7 +1364,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "Transport errors are failures to send or receive data between the drive controller and the disk. Large or rapidly increasing numbers of transport errors may be an indicator that the disk needs to be reseated, the transport cable needs to be replaced, the disk may needs to be replaced, or the drive controller needs to be replaced.",
           "fieldConfig": {
@@ -1403,7 +1407,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1439,7 +1444,7 @@
             "h": 8,
             "w": 10,
             "x": 10,
-            "y": 47
+            "y": 52
           },
           "id": 69,
           "options": {
@@ -1458,7 +1463,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_disk_transport_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -1480,14 +1485,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 30
       },
       "id": 61,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1499,7 +1504,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -1518,7 +1524,7 @@
             "h": 5,
             "w": 20,
             "x": 0,
-            "y": 57
+            "y": 61
           },
           "id": 45,
           "options": {
@@ -1540,7 +1546,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "sum by(node_id, bond, role) (qumulo_network_interface_is_down{instance=~\"$cluster\", node_id=~\"$nodes\"})",
@@ -1555,7 +1561,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1567,7 +1573,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1582,7 +1589,7 @@
             "h": 5,
             "w": 20,
             "x": 0,
-            "y": 62
+            "y": 66
           },
           "id": 43,
           "options": {
@@ -1599,12 +1606,12 @@
             },
             "textMode": "name"
           },
-          "pluginVersion": "9.1.2",
+          "pluginVersion": "9.2.2",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_network_interface_is_down{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -1620,7 +1627,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1633,7 +1640,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -1645,7 +1653,7 @@
             "h": 5,
             "w": 20,
             "x": 0,
-            "y": 67
+            "y": 71
           },
           "id": 47,
           "options": {
@@ -1662,12 +1670,12 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.1.2",
+          "pluginVersion": "9.2.2",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_network_interface_link_speed_bits_per_second",
@@ -1682,7 +1690,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1724,7 +1732,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               },
@@ -1736,7 +1745,7 @@
             "h": 8,
             "w": 7,
             "x": 0,
-            "y": 72
+            "y": 76
           },
           "id": 37,
           "options": {
@@ -1755,7 +1764,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "rate(qumulo_network_interface_transmitted_bytes_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval])",
@@ -1766,7 +1775,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "rate(qumulo_network_interface_received_bytes_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval])",
@@ -1782,7 +1791,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -1825,7 +1834,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1840,7 +1850,7 @@
             "h": 8,
             "w": 7,
             "x": 7,
-            "y": 72
+            "y": 76
           },
           "id": 41,
           "options": {
@@ -1859,7 +1869,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "rate(qumulo_network_interface_transmitted_packets_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval])",
@@ -1870,7 +1880,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "rate(qumulo_network_interface_received_packets_total{instance=~\"$cluster\", node_id=~\"$nodes\"}[$__rate_interval])",
@@ -1886,7 +1896,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "uid": "${datasource}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1928,7 +1938,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -1943,7 +1954,7 @@
             "h": 8,
             "w": 6,
             "x": 14,
-            "y": 72
+            "y": 76
           },
           "id": 39,
           "options": {
@@ -1962,7 +1973,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_network_interface_transmit_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -1974,7 +1985,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "PBFA97CFB590B2093"
+                "uid": "${datasource}"
               },
               "editorMode": "builder",
               "expr": "qumulo_network_interface_receive_errors_total{instance=~\"$cluster\", node_id=~\"$nodes\"}",
@@ -2002,12 +2013,31 @@
       {
         "current": {
           "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": "The Prometheus instance to query OpenMetrics from",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
           "text": "",
           "value": ""
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "qumulo_quorum_node_is_offline",
         "hide": 0,
@@ -2038,7 +2068,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "uid": "${datasource}"
         },
         "definition": "qumulo_quorum_node_is_offline{instance=~\\\"$cluster\\\"}",
         "hide": 0,
@@ -2067,6 +2097,6 @@
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 7,
+  "version": 8,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -24,7 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -326,6 +326,322 @@
             "mode": "absolute",
             "steps": [
               {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 0,
+        "y": 2
+      },
+      "id": 71,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^service_model$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Service Model",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 2,
+        "x": 2,
+        "y": 2
+      },
+      "id": 72,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^platform$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Platform",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 4,
+        "y": 2
+      },
+      "id": 73,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^max_node_failures$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Node Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 3,
+        "x": 7,
+        "y": 2
+      },
+      "id": 74,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^max_disk_failures$/",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_info{instance=~\"$cluster\"}",
+          "format": "table",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Disk Failures",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 0,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 20,
+        "x": 0,
+        "y": 4
+      },
+      "id": 75,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "9.2.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_node_info{instance=~\"$cluster\"}",
+          "format": "heatmap",
+          "legendFormat": "{{node_model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node Models",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
                 "color": "green",
                 "value": null
               },
@@ -342,7 +658,7 @@
         "h": 4,
         "w": 20,
         "x": 0,
-        "y": 2
+        "y": 8
       },
       "id": 55,
       "options": {
@@ -367,7 +683,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\", node_id=~\"$nodes\"}",
+          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\"}",
           "format": "heatmap",
           "legendFormat": "node {{node_id}}",
           "range": true,
@@ -436,7 +752,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 6
+        "y": 12
       },
       "id": 31,
       "options": {
@@ -552,7 +868,7 @@
         "h": 8,
         "w": 10,
         "x": 10,
-        "y": 6
+        "y": 12
       },
       "id": 34,
       "options": {
@@ -618,7 +934,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 14
+        "y": 20
       },
       "id": 33,
       "options": {
@@ -685,7 +1001,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 19
+        "y": 25
       },
       "id": 35,
       "options": {
@@ -728,7 +1044,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 30
       },
       "id": 59,
       "panels": [
@@ -747,8 +1063,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -840,8 +1155,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -907,8 +1221,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "green",
@@ -1002,8 +1315,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -1091,8 +1403,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -1169,7 +1480,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 31
       },
       "id": 61,
       "panels": [
@@ -1689,6 +2000,11 @@
   "templating": {
     "list": [
       {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
@@ -1751,6 +2067,6 @@
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -38,40 +38,58 @@
           "color": {
             "mode": "thresholds"
           },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "text",
+                "color": "green",
                 "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "uuid"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 286
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 2,
-        "w": 3,
+        "h": 3,
+        "w": 13,
         "x": 0,
         "y": 0
       },
-      "id": 77,
+      "id": 79,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
           ],
-          "fields": "/^name$/",
-          "values": false
+          "show": false
         },
-        "text": {},
-        "textMode": "auto"
+        "showHeader": true,
+        "sortBy": []
       },
       "pluginVersion": "9.2.2",
       "targets": [
@@ -81,139 +99,54 @@
             "uid": "${datasource}"
           },
           "editorMode": "builder",
+          "exemplar": false,
           "expr": "qumulo_info{instance=~\"$cluster\"}",
           "format": "table",
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "Cluster Name",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
+      "title": "Cluster Info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 11,
+              "__name__": 1,
+              "instance": 2,
+              "job": 3,
+              "max_drive_failures": 9,
+              "max_node_failures": 10,
+              "name": 4,
+              "platform": 7,
+              "service_model": 8,
+              "uuid": 5,
+              "version": 6
+            },
+            "renameByName": {
+              "max_drive_failures": "Max Drive Failures",
+              "max_node_failures": "Max Node Failures",
+              "name": "Cluster Name",
+              "platform": "Platform",
+              "service_model": "Service Model",
+              "uuid": "Cluster UUID",
+              "version": "Software Version"
+            }
           }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 3,
-        "y": 0
-      },
-      "id": 51,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^version$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
         }
       ],
-      "title": "Version",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 4,
-        "x": 5,
-        "y": 0
-      },
-      "id": 49,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^uuid$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "UUID",
-      "type": "stat"
+      "type": "table"
     },
     {
       "datasource": {
@@ -264,9 +197,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 2,
+        "h": 3,
         "w": 2,
-        "x": 9,
+        "x": 13,
         "y": 0
       },
       "id": 25,
@@ -319,269 +252,39 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 0,
-        "y": 2
-      },
-      "id": 71,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
+          "custom": {
+            "align": "auto",
+            "displayMode": "color-text",
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "false": {
+                  "color": "#73BF69",
+                  "index": 0,
+                  "text": "Online"
+                },
+                "true": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Offline"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "fields": "/^service_model$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Service Model",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 2,
-        "y": 2
-      },
-      "id": 72,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^platform$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Platform",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 4,
-        "y": 2
-      },
-      "id": 73,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^max_node_failures$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Node Failures",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 7,
-        "y": 2
-      },
-      "id": 74,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "/^max_drive_failures$/",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_info{instance=~\"$cluster\"}",
-          "format": "table",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Drive Failures",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
           "max": 0,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "transparent",
+                "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -589,25 +292,22 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 3,
+        "h": 6,
         "w": 20,
         "x": 0,
-        "y": 4
+        "y": 3
       },
       "id": 75,
       "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+        "footer": {
           "fields": "",
-          "values": false
+          "reducer": [
+            "sum"
+          ],
+          "show": false
         },
-        "textMode": "name"
+        "frameIndex": 0,
+        "showHeader": true
       },
       "pluginVersion": "9.2.2",
       "targets": [
@@ -617,81 +317,75 @@
             "uid": "${datasource}"
           },
           "editorMode": "builder",
+          "exemplar": false,
           "expr": "qumulo_node_info{instance=~\"$cluster\"}",
-          "format": "heatmap",
+          "format": "table",
+          "instant": true,
           "legendFormat": "{{node_model}}",
-          "range": true,
+          "range": false,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "builder",
+          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\"}",
+          "format": "table",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "Node Models",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
+      "title": "Node Info",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "node_id",
+            "mode": "inner"
           }
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 20,
-        "x": 0,
-        "y": 7
-      },
-      "id": 55,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "name"
-      },
-      "pluginVersion": "9.2.2",
-      "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "builder",
-          "expr": "qumulo_quorum_node_is_offline{instance=~\"$cluster\", node_id=~\"$nodes\"}",
-          "format": "heatmap",
-          "legendFormat": "node {{node_id}}",
-          "range": true,
-          "refId": "A"
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Value #A": true,
+              "Value #B": false,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "instance 1": true,
+              "instance 2": true,
+              "job 1": true,
+              "job 2": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #B": "Status",
+              "job 2": "",
+              "node_id": "Node ID",
+              "node_model": "Node Model"
+            }
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "boolean",
+                "targetField": "Value #B"
+              }
+            ],
+            "fields": {}
+          }
         }
       ],
-      "title": "Node Online",
-      "type": "stat"
+      "type": "table"
     },
     {
       "datasource": {
@@ -752,7 +446,7 @@
         "h": 8,
         "w": 10,
         "x": 0,
-        "y": 11
+        "y": 9
       },
       "id": 31,
       "options": {
@@ -868,7 +562,7 @@
         "h": 8,
         "w": 10,
         "x": 10,
-        "y": 11
+        "y": 9
       },
       "id": 34,
       "options": {
@@ -934,7 +628,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 19
+        "y": 17
       },
       "id": 33,
       "options": {
@@ -1001,7 +695,7 @@
         "h": 5,
         "w": 20,
         "x": 0,
-        "y": 24
+        "y": 22
       },
       "id": 35,
       "options": {
@@ -1044,7 +738,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 27
       },
       "id": 59,
       "panels": [
@@ -1063,8 +757,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -1156,8 +849,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1223,8 +915,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "green",
@@ -1318,8 +1009,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -1407,8 +1097,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -1485,7 +1174,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 28
       },
       "id": 61,
       "panels": [
@@ -1504,8 +1193,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "#EAB839",
@@ -1573,8 +1261,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1640,8 +1327,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1732,8 +1418,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               },
@@ -1834,8 +1519,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1938,8 +1622,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2097,6 +1780,6 @@
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 8,
+  "version": 12,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/qumulo/node.json
+++ b/grafana/provisioning/dashboards/qumulo/node.json
@@ -1035,7 +1035,7 @@
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": false
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -1110,32 +1110,7 @@
                 ]
               }
             },
-            "overrides": [
-              {
-                "__systemRef": "hideSeriesFrom",
-                "matcher": {
-                  "id": "byNames",
-                  "options": {
-                    "mode": "exclude",
-                    "names": [
-                      "Node 4 bay 3 (hdd)"
-                    ],
-                    "prefix": "All except:",
-                    "readOnly": true
-                  }
-                },
-                "properties": [
-                  {
-                    "id": "custom.hideFrom",
-                    "value": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": true
-                    }
-                  }
-                ]
-              }
-            ]
+            "overrides": []
           },
           "gridPos": {
             "h": 8,
@@ -1149,7 +1124,7 @@
               "calcs": [],
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": false
+              "showLegend": true
             },
             "tooltip": {
               "mode": "single",
@@ -1781,13 +1756,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Node Overview",
   "uid": "R66fOPnVz",
-  "version": 15,
+  "version": 18,
   "weekStart": ""
 }


### PR DESCRIPTION
- Combine cluster info panels into one table
- Combine node info and node status panels into one node info table
- Add a top-level variable for the datasource so that customers can easily swap out the datasource
- Disk metrics will now show up even if the view time range is shorter than the metric cache interval of two hours for those metrics
- Transport errors had the lines for all the drives hidden for some reason, those will now all show up
![Screen Shot 2023-02-24 at 12 11 23 PM](https://user-images.githubusercontent.com/36055156/221281695-fabdd652-bc76-4e2b-8206-82647f658a82.png)
Node info/cluster info panel
![Screen Shot 2023-02-24 at 12 12 03 PM](https://user-images.githubusercontent.com/36055156/221281745-dfdeff12-7c69-41ac-95c9-b5dcc3eb2df3.png)
Cluster info panel
![Screen Shot 2023-02-24 at 12 17 56 PM](https://user-images.githubusercontent.com/36055156/221282710-f22428c8-6481-42f2-913d-892914943f03.png)
Disk metrics being displayed in a time range of 5 minutes, and transport errors actually showing the data
