### PR TITLE
Link to git docs for setting up git and cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This section explains the initial configuration of the Qumulo Monitoring Dashboa
 ### Prerequisites
 Before you begin, ensure that you have the following (or higher) software versions:
 
+* [Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
 * Docker Engine 1.13
 * Docker Compose 1.11
 * Qumulo Core 5.3.0
@@ -34,11 +35,7 @@ Before you begin, ensure that you have the following (or higher) software versio
 
 1. Log in to your Docker host.
 
-1. Use the `git` CLI to clone this repository.
-
-   ```bash
-   git clone git@github.com:Qumulo/qumulo-monitoring-dashboard.git
-   ```
+1. Use the `git` CLI to [clone this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
 
 1. Navigate to the `qumulo-monitoring-dashboard` directory.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This section explains the initial configuration of the Qumulo Monitoring Dashboa
 
 <a id="prerequisites"></a>
 ### Prerequisites
-Before you begin, ensure that you have the following (or higher) software versions:
+Before you begin, ensure that you have the following minimum software versions:
 
 * [Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
 * Docker Engine 1.13

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ Before you begin, ensure that you have the following minimum software versions:
 
 1. Log in to your Docker host.
 
-1. Use the `git` CLI to [clone this repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository).
+1. Use the `git` CLI to clone this repository.
+
+   For more information, see [Cloning a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) in the GitHub documentation.
 
 1. Navigate to the `qumulo-monitoring-dashboard` directory.
 


### PR DESCRIPTION
The previous instructions gave a command for cloning from SSH, which is not github's recommended setup. Instead, link to instructions on how to set up git and make that a prerequisite, and link to documentation on how to clone to provide users with the ability to use HTTPS or SSH.