### PR TITLE
Add domain_url as a legend for LDAP metrics

### DIFF
--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -1469,7 +1469,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1484,7 +1484,7 @@
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operations_total{instance=~\"$cluster\"}[$__rate_interval])",
-          "legendFormat": "Operations",
+          "legendFormat": "{{domain_url}}",
           "range": true,
           "refId": "A"
         }
@@ -1557,7 +1557,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1572,7 +1572,7 @@
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operation_errors_total{instance=~\"$cluster\"}[$__rate_interval])",
-          "legendFormat": "Errors",
+          "legendFormat": "{{domain_url}}",
           "range": true,
           "refId": "A"
         }
@@ -1645,7 +1645,7 @@
           "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": false
+          "showLegend": true
         },
         "tooltip": {
           "mode": "single",
@@ -1660,7 +1660,7 @@
           },
           "editorMode": "builder",
           "expr": "rate(qumulo_ldap_operation_referrals_total{instance=~\"$cluster\"}[$__rate_interval])",
-          "legendFormat": "Referrals",
+          "legendFormat": "{{domain_url}}",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
In 6.1.1 domain_url added as a label on all AD and LDAP metrics. Lets make it the legend on the LDAP operation metrics, which previously had no legend. server_url is differentiating enough for the other AD and LDAP metrics.