### PR TITLE
Make ANQ clusters show up on the cluster dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ This section explains how to verify that Grafana can query Prometheus and displa
 
    Metrics for your cluster begin to populate graphs.
 
+   **ℹ️ Note:** The **Cluster Info** and **Node Info** panels may take up to 24 hours to fully populate after initial setup.
+
 <a id="configure-grafana-alerts"></a>
 ### Step 7: Configure Grafana Alert Notifications
 This section explains how to configure Grafana alerts to notify you through email, Slack, or an alerting tool.

--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -2025,14 +2025,14 @@
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
-        "definition": "qumulo_quorum_node_is_offline",
+        "definition": "qumulo_fs_capacity_bytes",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "cluster",
         "options": [],
         "query": {
-          "query": "qumulo_quorum_node_is_offline",
+          "query": "qumulo_fs_capacity_bytes",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,


### PR DESCRIPTION
ANQ clusters would not previously show up on the cluster dashboard because we populated the $cluster variable using a per-node metric, which are not emitted on ANQ clusters. Changing it to query a cluster-wide metric instead fixes the issue.