### PR TITLE
Correcting cluster.json latency graphs from "ms" to "s"

### DIFF
--- a/grafana/provisioning/dashboards/qumulo/cluster.json
+++ b/grafana/provisioning/dashboards/qumulo/cluster.json
@@ -819,7 +819,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -1365,7 +1365,7 @@
               }
             ]
           },
-          "unit": "dtdurationms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -1919,7 +1919,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },


### PR DESCRIPTION
The AD netlogon latency, LDAP latency, and protocol ops latency graphs were set with units in "ms" which is incorrect as the metrics are all in seconds